### PR TITLE
Add-Context-Update-Point

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-		
+		
+import xbmc		
+		
+if __name__ == '__main__':		
+    xbmc.executebuiltin('XBMC.RunPlugin(plugin://plugin.video.osmosis/?url=&mode=4)')

--- a/addon.xml
+++ b/addon.xml
@@ -44,4 +44,13 @@
 			<screenshot>fanart.jpg</screenshot>
 		</assets>
 	</extension>
+    <extension point="kodi.context.item">
+    <menu id="kodi.core.main">
+
+      <item library="addon.py">
+        <label>Osmosis-Update</label>
+        <visible>true</visible>
+      </item>
+	</menu>
+    </extension>
 </addon>

--- a/addon.xml
+++ b/addon.xml
@@ -44,13 +44,12 @@
 			<screenshot>fanart.jpg</screenshot>
 		</assets>
 	</extension>
-    <extension point="kodi.context.item">
-    <menu id="kodi.core.main">
-
-      <item library="addon.py">
-        <label>Osmosis-Update</label>
-        <visible>true</visible>
-      </item>
-	</menu>
-    </extension>
+        <extension point="kodi.context.item">
+        <menu id="kodi.core.main">
+            <item library="addon.py">
+            <label>Osmosis-Update</label>
+            <visible>true</visible>
+        </item>
+        </menu>
+        </extension>
 </addon>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,7 +2,7 @@
 <settings>
     <category label="32000">
         <setting label="32014" type="bool" id="USE_MYSQL" default="false"/>
-        <setting label="32015" type="bool" id="Find_SQLite_DB" default="false" subsetting="true" visible="eq(-1,false)"/>
+        <setting label="32015" type="bool" id="Find_SQLite_DB" default="true" subsetting="true" visible="eq(-1,false)"/>
         <setting label="32003" type="folder" id="STRM_LOC" source="auto" default="special://userdata/addon_data/plugin.video.osmosis/strms"/>   
         <setting label="32004" type="folder" id="MediaList_LOC" source="auto" default="special://userdata/addon_data/plugin.video.osmosis"/>
         <setting label="32006" type="enum" id="Link_Type" values="OSMOSIS|Original Plugin" default="0"/>


### PR DESCRIPTION
Hi @Maven85 ,

habe mal ein allgemeinen Context-Menüeintrag für das Update-Menü hinzugefügt.
So kann man jetzt, wenn man irgendwo drin ist (egal ob Netflix, Amazon, etc.) das Osmosis-Update-Menü öffnen und die Einträge zum updaten auswählen.

Gruß Gismo :-)